### PR TITLE
Remove leading space from keywords.txt identifier

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -11,6 +11,6 @@
 # Methods and Functions (KEYWORD2)
 #######################################
 
-getFreeMemory KEYWORD2
-memoryCheck KEYWORD2
-getMinMemory KEYWORD2
+getFreeMemory	KEYWORD2
+memoryCheck	KEYWORD2
+getMinMemory	KEYWORD2


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords